### PR TITLE
Add pattern for caching template fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ install the Node requirements.
     cp bga_database/local_settings.py.example bga_database/local_settings.py
     ```
 
-5. Create your database, add a superuser, and load the `PensionFund` fixtures.
+5. Create your database, add a superuser, create the cache table, and load the
+`PensionFund` fixtures.
 
 
     ```bash
     createdb bga_pensions && python manage.py migrate
+    python manage.py createcachetable
     python manage.py createsuperuser  # complete the prompts
     python manage.py loaddata data/fixtures/pension_fund.json
     ```

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,7 @@
 
 {% load static %}
 {% load compress %}
+{% load cache %}
 
 {% block title %}Home{% endblock %}
 
@@ -46,6 +47,7 @@
   </div>
 </div>
 
+{% cache 10000 system_charts %}
 <div class="row pt-5 pb-5" id="funding-by-system">
   <div class="col-lg-10 offset-lg-1">
     <h3 class="pl-2 pb-4"><strong>Funding Distribution by Pension System</strong></h3>
@@ -103,6 +105,7 @@
     <div id="downstate-container"></div>
   </div>
 </div>
+{% endcache %}
 
 <div class="row pt-5 pb-5 hidden" id="funding-by-system-no-data">
   <div class="col-lg-10 offset-lg-1">No data :-(</div>


### PR DESCRIPTION
## Description

This PR exemplifies [Django's template fragment caching strategy](https://docs.djangoproject.com/en/2.2/topics/cache/#template-fragment-caching). This strategy allows for selective caching of load intensive but primarily static elements, while allowing for other elements (e.g., elements that display information specific to the user) to remain dynamic.

## Notes

- The caching setup for salaries has already been done. The work will be to remove the view-level caching directives, and instead add `{% cache %}` blocks to heavy portions of the template. In general, this means charts and tables, though I'd recommend using `django-debug-toolbar` to identify the worst offenders.
- **NOTE:**  `django-debug-toolbar` will not register calls to the template fragment cache: https://github.com/jazzband/django-debug-toolbar/issues/877#issuecomment-251877720. Instead, look for a reduced number of queries on page load. (See: https://dizballanze.com/django-project-optimization-part-3/)