### PR TITLE
Get email settings from env vars

### DIFF
--- a/bga_database/settings.py
+++ b/bga_database/settings.py
@@ -158,6 +158,13 @@ EMAIL_CONFIG = env.email(
 
 vars().update(EMAIL_CONFIG)
 
+EMAIL_USE_TLS = True
+EMAIL_HOST = env('EMAIL_HOST', default='')
+EMAIL_HOST_USER = env('EMAIL_HOST_USER', default='')
+EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD', default='')
+EMAIL_PORT = 587
+DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL', default='')
+
 MAILCHIMP_LIST_ID = env('MAILCHIMP_LIST_ID', default='')
 MAILCHIMP_API_KEY = env('MAILCHIMP_API_KEY', default='')
 MAILCHIMP_SERVER = env('MAILCHIMP_SERVER', default='')


### PR DESCRIPTION
## Overview

I believe most email config vars weren't being set or imported into settings, preventing validation emails from being sent. This allows for the app to grab those variables.

If this is merged I'll add those vars to the staging/production apps.

### Notes
I tried setting up a review app for this to make testing easier (hence all those deployments), and got a server error that made it seem like the version of postgres heroku was using wasn't compatible with the version of django that we're using. In trying to fix this I ended up in dependency hell, so for now local testing it is! 🎉 

 I still have those changes on a different branch in case we did want to set that up in the future.

## Testing Instructions
 - In Bitwarden, search for "BGA Email Sending Credentials" and paste those values into `.env.example` (the default .env file the container uses, remember to undo after testing)
 - If you haven't built the app since 10/12/23, build it to get the recent mailchimp-auth changes
 - Bring up the app and trigger the modal
 - Use an email that hasn't been used for mailchimp yet in the signup form
 - Confirm that an email comes through to that address
 - Click the verification link
 - Confirm that the page gives you a success message, and that a confirmation email comes through
